### PR TITLE
import cloudpickle directly

### DIFF
--- a/ipython_kernel/pickleutil.py
+++ b/ipython_kernel/pickleutil.py
@@ -97,7 +97,7 @@ def use_cloudpickle():
     
     adds support for object methods and closures to serialization.
     """
-    from cloud.serialization import cloudpickle
+    import cloudpickle
     
     global pickle
     pickle = cloudpickle


### PR DESCRIPTION
Now that `cloudpickle` is in its [own package up on PyPI](https://pypi.python.org/pypi/cloudpickle) it can be installed and used directly.

Benefits:

* supports Python 3
* has its own suite of tests (nothing public prior)
* active development

/cc @ogrisel